### PR TITLE
chore: add aarch64-linux platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,9 @@ GEM
     webrick (1.8.2)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-22
+  arm64-darwin-25
   x86_64-darwin-21
   x86_64-linux
 
@@ -30,7 +32,7 @@ DEPENDENCIES
   webrick
 
 RUBY VERSION
-   ruby 3.4.9p0
+  ruby 3.4.9p0
 
 BUNDLED WITH
-   2.4.6
+  4.0.9


### PR DESCRIPTION
## Summary

- Adds `aarch64-linux` platform to `Gemfile.lock` to resolve CI build error on Dokku
- Also picks up `arm64-darwin-25` from local environment
- Corrects `RUBY VERSION` indentation and updates `BUNDLED WITH` to 4.0.9

## Test plan

- [ ] CI Docker smoke test passes (HTTP 410)
- [ ] Dokku deployment succeeds on aarch64-linux host

🤖 Generated with [Claude Code](https://claude.com/claude-code)