### PR TITLE
ci: migrate dokku deploy to Cloudflare tunnel SSH

### DIFF
--- a/.github/workflows/dokku.yaml
+++ b/.github/workflows/dokku.yaml
@@ -6,6 +6,7 @@ on:
       - master
       - dokku
       - "dokku**"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,10 +19,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Configure SSH for Cloudflare tunnel
+        run: |
+          mkdir -p ~/.ssh
+          cat >> ~/.ssh/config <<'EOF'
+          Host dokku-ssh.iphoting.cc
+            ProxyCommand docker run --rm -i cloudflare/cloudflared:latest access ssh --hostname %h
+            StrictHostKeyChecking no
+          EOF
       - name: Push to dokku
         uses: dokku/github-action@v1.4.0
         with:
           # specify `--force` as a flag for git pushes
           git_push_flags: '--force'
-          git_remote_url: 'ssh://dokku@c.iphoting.cc:3022/00-default-dokku'
+          git_remote_url: 'ssh://dokku@dokku-ssh.iphoting.cc/00-default-dokku'
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Replaces direct SSH to `c.iphoting.cc:3022` with Cloudflare tunnel via `dokku-ssh.iphoting.cc`
- Uses `docker run cloudflare/cloudflared:latest` as SSH ProxyCommand — no install step needed
- `SSH_PRIVATE_KEY` secret unchanged

## Test plan

- [ ] Merge to `master` and verify the deploy workflow succeeds end-to-end
- [ ] Confirm port 3022 can be firewalled off after all 6 repos are merged

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mx3TtNcPLxofoGoc79QZ22)_