### PR TITLE
ci: fix dokku deploy — use direct git push over Cloudflare tunnel

### DIFF
--- a/.github/workflows/dokku.yaml
+++ b/.github/workflows/dokku.yaml
@@ -31,6 +31,8 @@ jobs:
             ProxyCommand docker run --rm -i cloudflare/cloudflared:latest access ssh --hostname %h
             IdentityFile ~/.ssh/id_rsa
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
           EOF
           git remote add dokku ssh://dokku@dokku-ssh.iphoting.cc/00-default-dokku
           git push dokku HEAD:master --force

--- a/.github/workflows/dokku.yaml
+++ b/.github/workflows/dokku.yaml
@@ -19,18 +19,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Configure SSH for Cloudflare tunnel
+      - name: Set up SSH and push to dokku
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
           cat >> ~/.ssh/config <<'EOF'
           Host dokku-ssh.iphoting.cc
             ProxyCommand docker run --rm -i cloudflare/cloudflared:latest access ssh --hostname %h
+            IdentityFile ~/.ssh/id_rsa
             StrictHostKeyChecking no
           EOF
-      - name: Push to dokku
-        uses: dokku/github-action@v1.4.0
-        with:
-          # specify `--force` as a flag for git pushes
-          git_push_flags: '--force'
-          git_remote_url: 'ssh://dokku@dokku-ssh.iphoting.cc/00-default-dokku'
-          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          git remote add dokku ssh://dokku@dokku-ssh.iphoting.cc/00-default-dokku
+          git push dokku HEAD:master --force


### PR DESCRIPTION
## Summary

- Fixes the deploy workflow broken in #16 — `dokku/github-action` runs in its own container and can't use the runner's SSH config/ProxyCommand
- Replaces it with a direct `git push` on the runner, where the Cloudflare tunnel ProxyCommand is active
- Adds `ServerAliveInterval`/`ServerAliveCountMax` keepalives to prevent disconnect during long builds

## Test plan

- [x] Verified working on `dokku-cf-tunnel-test` branch

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mx3TtNcPLxofoGoc79QZ22)_